### PR TITLE
Jsx type: use load instead of transform

### DIFF
--- a/types/jsx.js
+++ b/types/jsx.js
@@ -1,4 +1,7 @@
+const fs = require('fs');
+const url = require('url');
 const Babel = require('@babel/core');
+const fetch = require('node-fetch');
 
 function parseQuery(queryString) {
   const query = {};
@@ -15,7 +18,22 @@ function parseQuery(queryString) {
 }
 
 module.exports = {
-  transform(src, id) {
+  async load(id) {
+    let src;
+    if (/https:/i.test(id)) {
+      const o = url.parse(id, true);
+      o.query['noimport'] = 1 + '';
+      id = url.format(o);
+      
+      const res = await fetch(id);
+      src = await res.text();
+    } else if (/^\//.test(id)) {
+      src = await fs.promises.readFile(id, 'utf8');
+    } else {
+      console.warn('unknown jsx id', id);
+      src = null;
+    }
+
     const components = (() => {
       const match = id.match(/#([\s\S]+)$/);
       if (match) {

--- a/types/metaversefile.js
+++ b/types/metaversefile.js
@@ -37,23 +37,25 @@ module.exports = {
             /* if (Array.isArray(components)) {
               o.query.components = encodeURIComponent(JSON.stringify(components));
             } */
-            let s = '/@proxy/' + start_url;
+            const o = url.parse(start_url, true);
+            o.pathname = '/@proxy/' + o.pathname;
             if (Array.isArray(components)) {
-              s += '#components=' + encodeURIComponent(JSON.stringify(components));
+              o.hash = '#components=' + encodeURIComponent(JSON.stringify(components));
             }
+            let s = url.format(o);
             // console.log('new metaversefile id 1', {id, importer, result, start_url, s});
             return s;
           } else if (/^https?:\/\//.test(id)) {
             const o = url.parse(id, true);
             // console.log('new metaversefile id 1', {id, importer, start_url, o}, [path.dirname(o.pathname), start_url]);
             o.pathname = path.join(path.dirname(o.pathname), start_url);
+            if (Array.isArray(components)) {
+              o.hash = '#components=' + encodeURIComponent(JSON.stringify(components));
+            }
             /* if (Array.isArray(components)) {
               o.query.components = encodeURIComponent(JSON.stringify(components));
             } */
             let s = url.format(o);
-            if (Array.isArray(components)) {
-              s += '#components=' + encodeURIComponent(JSON.stringify(components));
-            }
             // console.log('new metaversefile id 2', {id, importer, result, start_url, s});
             return s;
           } else if (/^\//.test(id)) {

--- a/util.js
+++ b/util.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const fs = require('fs');
+const url = require('url');
 const fetch = require('node-fetch');
 
 const cwd = process.cwd();
@@ -21,12 +22,16 @@ module.exports.resolveFileFromId = resolveFileFromId;
 
 const fetchFileFromId = async (id, importer, encoding = null) => {
   id = id
-   .replace(/^\/@proxy\//, '')
+   // .replace(/^\/@proxy\//, '')
    .replace(/^(https?:\/(?!\/))/, '$1/');
   if (/^https?:\/\//.test(id)) {
+    const u = url.parse(id, true);
+    u.query.noimport = 1 + '';
+    id = url.format(u);
     const res = await fetch(id)
     if (encoding === 'utf8') {
-      return await res.text();
+      const s = await res.text();
+      return s;
     } else {
       const arrayBuffer = await res.arrayBuffer();
       const buffer = Buffer.from(arrayBuffer);


### PR DESCRIPTION
This fixes a bug with nested apps, where the jsx type fetch would fetch the compiled version of the app, resulting in a double compile (double export), which causes a crash.