### PR TITLE
Add lore type template

### DIFF
--- a/plugins/rollup.js
+++ b/plugins/rollup.js
@@ -32,6 +32,7 @@ const text = require('../types/text.js');
 // const background = require('../types/background.js');
 const rendersettings = require('../types/rendersettings.js');
 const spawnpoint = require('../types/spawnpoint.js');
+const lore = require('../types/lore.js');
 const group = require('../types/group.js');
 const directory = require('../types/directory.js');
 const loaders = {
@@ -56,6 +57,7 @@ const loaders = {
   // background,
   rendersettings,
   spawnpoint,
+  lore,
   group,
   '': directory,
 };
@@ -75,7 +77,7 @@ const _getType = id => {
     }
     let extension;
     let match2;
-    if (match2 = type.match(/^application\/(light|text|rendersettings|group|spawnpoint)$/)) {
+    if (match2 = type.match(/^application\/(light|text|rendersettings|spawnpoint|lore|group)$/)) {
       extension = match2[1];
     } else {
       extension = mimeTypes.extension(type);

--- a/type_templates/lore.js
+++ b/type_templates/lore.js
@@ -1,0 +1,39 @@
+// import * as THREE from 'three';
+import metaversefile from 'metaversefile';
+const {useApp, useLoreAIScene, useCleanup} = metaversefile;
+
+export default e => {
+  const app = useApp();
+  app.appType = 'lore';
+
+  const loreAIScene = useLoreAIScene();
+
+  const srcUrl = ${this.srcUrl};
+
+  let live = true;
+  let setting = null;
+  (async () => {
+    const res = await fetch(srcUrl);
+    if (!live) return;
+    let j = await res.json();
+    // console.log('got lore json', j);
+    if (!live) return;
+    if (Array.isArray(j)) {
+      j = j.join('\\n');
+    }
+    if (typeof j === 'string') {
+      setting = loreAIScene.addSetting(j);
+    }
+  })();
+  
+  useCleanup(() => {
+    live = false;
+
+    if (setting !== null) {
+      loreAIScene.removeSetting(setting);
+      setting = null;
+    }
+  });
+
+  return app;
+};

--- a/types/lore.js
+++ b/types/lore.js
@@ -1,0 +1,22 @@
+const path = require('path');
+const fs = require('fs');
+const {fillTemplate, createRelativeFromAbsolutePath} = require('../util.js');
+
+const templateString = fs.readFileSync(path.join(__dirname, '..', 'type_templates', 'lore.js'), 'utf8');
+// const cwd = process.cwd();
+
+module.exports = {
+  load(id) {
+
+    id = createRelativeFromAbsolutePath(id);
+    
+    const code = fillTemplate(templateString, {
+      srcUrl: JSON.stringify(id),
+    });
+    // console.log('got image id', id);
+    return {
+      code,
+      map: null,
+    };
+  },
+};


### PR DESCRIPTION
Adds `application/lore` type support, meant to be a consequential lore descriptor in scenes.

Needs more `loreAIScene` methods before it will be loadable in the host engine.