### PR TITLE
Disable transmission on GLB models

### DIFF
--- a/type_templates/glb.js
+++ b/type_templates/glb.js
@@ -105,6 +105,10 @@ export default e => {
                 o.material[mapType].anisotropy = aaLevel;
               }
             });
+            if (o.material.transmission !== undefined) {
+              o.material.transmission = 0;
+              o.material.opacity = 0.25;
+            }
           }
         });
       };


### PR DESCRIPTION
This was causing the scene to be rendered twice, halving performance.

https://github.com/webaverse/app/issues/2400