### PR TITLE
JSON component hashes

### DIFF
--- a/type_templates/background.js
+++ b/type_templates/background.js
@@ -2,25 +2,13 @@ import * as THREE from 'three';
 import metaversefile from 'metaversefile';
 const {useApp, useFrame, useCleanup, useInternals} = metaversefile;
 
-/* const flipGeomeryUvs = geometry => {
-  for (let i = 0; i < geometry.attributes.uv.array.length; i += 2) {
-    const j = i + 1;
-    geometry.attributes.uv.array[j] = 1 - geometry.attributes.uv.array[j];
-  }
-}; */
-// console.log('got gif 0');
-
 export default e => {
   const app = useApp();
   app.appType = 'background';
   
   const {scene} = useInternals();
-  
-  // const {gifLoader} = useLoaders();
-  // const physics = usePhysics();
 
-  const srcUrl = '${this.srcUrl}';
-  // console.log('got light', {srcUrl});
+  const srcUrl = ${this.srcUrl};
   
   let live = true;
   (async () => {

--- a/type_templates/fog.js
+++ b/type_templates/fog.js
@@ -2,29 +2,13 @@ import * as THREE from 'three';
 import metaversefile from 'metaversefile';
 const {useApp, useInternals, useCleanup} = metaversefile;
 
-/* const flipGeomeryUvs = geometry => {
-  for (let i = 0; i < geometry.attributes.uv.array.length; i += 2) {
-    const j = i + 1;
-    geometry.attributes.uv.array[j] = 1 - geometry.attributes.uv.array[j];
-  }
-}; */
-// console.log('got gif 0');
-
 export default e => {
   const app = useApp();
   app.appType = 'fog';
-  
-  // const world = useWorld();
-  
-  // const {gifLoader} = useLoaders();
-  // const physics = usePhysics();
 
-  const srcUrl = '${this.srcUrl}';
-  // console.log('got light', {srcUrl});
+  const srcUrl = ${this.srcUrl};
 
   const {rootScene} = useInternals();
-
-  // console.log('got fog src url', srcUrl, rootScene);
 
   let live = true;
   (async () => {

--- a/type_templates/gif.js
+++ b/type_templates/gif.js
@@ -10,8 +10,6 @@ const flipGeomeryUvs = geometry => {
   }
 };
 
-// console.log('got gif 0');
-
 export default e => {
   const app = useApp();
   app.appType = 'gif';
@@ -20,8 +18,7 @@ export default e => {
   const {gifLoader} = useLoaders();
   const physics = usePhysics();
   
-  const srcUrl = '${this.srcUrl}';
-  // console.log('got gif 1');
+  const srcUrl = ${this.srcUrl};
   
   const geometry = new THREE.PlaneBufferGeometry(1, 1);
   /* geometry.boundingBox = new THREE.Box3(
@@ -43,10 +40,6 @@ export default e => {
   model.frustumCulled = false;
   app.add(model);
   model.updateMatrixWorld();
-  
-  // const mesh = new THREE.Object3D();
-  // mesh.add(model);
-  // mesh.contentId = contentId;
 
   let textures;
   let physicsIds = [];
@@ -104,8 +97,6 @@ export default e => {
       material.map = textures[frameIndex];
     }
   });
-  
-  // console.log('got gif 2', mesh);
   
   return app;
 };

--- a/type_templates/glb.js
+++ b/type_templates/glb.js
@@ -25,7 +25,7 @@ export default e => {
   const localPlayer = useLocalPlayer();
   const Avatar = useAvatarInternal();
 
-  const srcUrl = '${this.srcUrl}';
+  const srcUrl = ${this.srcUrl};
   const components = (
     ${this.components}
   );

--- a/type_templates/glbb.js
+++ b/type_templates/glbb.js
@@ -17,7 +17,7 @@ export default () => {
   
   let _update = null;
   
-  const srcUrl = '${this.srcUrl}';
+  const srcUrl = ${this.srcUrl};
   (async () => {
     const {shadertoyLoader} = useLoaders();
     const shadertoyRenderer = await shadertoyLoader.load(srcUrl, {

--- a/type_templates/gltj.js
+++ b/type_templates/gltj.js
@@ -10,7 +10,7 @@ export default e => {
   const app = useApp();
   app.appType = 'gltj';
 
-  const srcUrl = '${this.srcUrl}';
+  const srcUrl = ${this.srcUrl};
 
   let _update = null;
   e.waitUntil((async () => {

--- a/type_templates/group.js
+++ b/type_templates/group.js
@@ -2,14 +2,6 @@ import * as THREE from 'three';
 import metaversefile from 'metaversefile';
 const {useApp, useFrame, useActivate, useWear, useUse, useCleanup, getNextInstanceId} = metaversefile;
 
-/* const flipGeomeryUvs = geometry => {
-  for (let i = 0; i < geometry.attributes.uv.array.length; i += 2) {
-    const j = i + 1;
-    geometry.attributes.uv.array[j] = 1 - geometry.attributes.uv.array[j];
-  }
-}; */
-// console.log('got gif 0');
-
 const localMatrix = new THREE.Matrix4();
 
 function getObjectUrl(object) {
@@ -35,12 +27,8 @@ export default e => {
   app.appType = 'group';
   
   // console.log('group load', app, app.position.toArray());
-  
-  // const {gifLoader} = useLoaders();
-  // const physics = usePhysics();
 
-  const srcUrl = '${this.srcUrl}';
-  // console.log('got light', {srcUrl});
+  const srcUrl = ${this.srcUrl};
   
   const _updateSubAppMatrix = subApp => {
     // localMatrix.decompose(subApp.position, subApp.quaternion, subApp.scale);

--- a/type_templates/html.js
+++ b/type_templates/html.js
@@ -47,7 +47,7 @@ export default e => {
     camera,
     iframeContainer,
   } = useInternals();
-  const href = '${this.srcUrl}';
+  const href = ${this.srcUrl};
   const res = app.getComponent('resolution');
   const width = res[0];
   const height = res[1];

--- a/type_templates/image.js
+++ b/type_templates/image.js
@@ -19,7 +19,7 @@ export default e => {
   // const {gifLoader} = useLoaders();
   const physics = usePhysics();
 
-  const srcUrl = '${this.srcUrl}';
+  const srcUrl = ${this.srcUrl};
   // console.log('got gif 1');
 
   const physicsIds = [];

--- a/type_templates/light.js
+++ b/type_templates/light.js
@@ -11,12 +11,8 @@ export default e => {
   app.light = null;
   
   const world = useWorld();
-  
-  // const {gifLoader} = useLoaders();
-  // const physics = usePhysics();
 
-  const srcUrl = '${this.srcUrl}';
-  // console.log('got light', {srcUrl});
+  const srcUrl = ${this.srcUrl};
 
   const addShadows = (light, params) => {
     light.castShadow = true; 

--- a/type_templates/rendersettings.js
+++ b/type_templates/rendersettings.js
@@ -6,25 +6,17 @@ export default e => {
   const app = useApp();
   app.appType = 'rendersettings';
   
-  // const world = useWorld();
   const postProcessing = usePostProcessing();
-  
-  // const {gifLoader} = useLoaders();
-  // const physics = usePhysics();
 
-  const srcUrl = '${this.srcUrl}';
-  // console.log('got light', {srcUrl});
+  const srcUrl = ${this.srcUrl};
 
   const {rootScene} = useInternals();
-
-  // console.log('got fog src url', srcUrl, rootScene);
 
   let live = true;
   (async () => {
     const res = await fetch(srcUrl);
     if (!live) return;
     const j = await res.json();
-    // console.log('got rendersettings', j);
     if (!live) return;
     if (j) {
       const {background} = j;
@@ -44,7 +36,7 @@ export default e => {
           const {args = []} = fog;
           rootScene.fog = new THREE.FogExp2(new THREE.Color(args[0][0]/255, args[0][1]/255, args[0][2]/255).getHex(), args[1]);
         } else {
-          console.warn('unknown fog type:', fog.fogType);
+          console.warn('unknown rendersettings fog type:', fog.fogType);
         }
       }
       

--- a/type_templates/scn.js
+++ b/type_templates/scn.js
@@ -25,7 +25,7 @@ export default e => {
   const app = useApp();
   app.appType = 'scn';
   
-  const srcUrl = '${this.srcUrl}';
+  const srcUrl = ${this.srcUrl};
   
   let live = true;
   e.waitUntil((async () => {

--- a/type_templates/spawnpoint.js
+++ b/type_templates/spawnpoint.js
@@ -6,7 +6,7 @@ export default e => {
   const app = useApp();
   app.appType = 'spawnpoint';
   
-  const srcUrl = '${this.srcUrl}';
+  const srcUrl = ${this.srcUrl};
 
   (async () => {
     const res = await fetch(srcUrl);

--- a/type_templates/text.js
+++ b/type_templates/text.js
@@ -30,7 +30,7 @@ export default e => {
   app.appType = 'text';
   app.text = null;
   
-  const srcUrl = '${this.srcUrl}';
+  const srcUrl = ${this.srcUrl};
   
   e.waitUntil((async () => {
     const res = await fetch(srcUrl);

--- a/type_templates/vox.js
+++ b/type_templates/vox.js
@@ -11,7 +11,7 @@ export default e => {
   
   const physics = usePhysics();
 
-  const srcUrl = '${this.srcUrl}';
+  const srcUrl = ${this.srcUrl};
 
   const physicsIds = [];
   const staticPhysicsIds = [];

--- a/type_templates/vrm.js
+++ b/type_templates/vrm.js
@@ -121,7 +121,7 @@ export default e => {
   app.skinnedVrm = null;
   app.unskinnedVrm = null;
   
-  const srcUrl = '${this.srcUrl}';
+  const srcUrl = ${this.srcUrl};
   const components = (
     ${this.components}
   );

--- a/types/background.js
+++ b/types/background.js
@@ -11,7 +11,7 @@ module.exports = {
     id = createRelativeFromAbsolutePath(id);
 
     const code = fillTemplate(templateString, {
-      srcUrl: id,
+      srcUrl: JSON.stringify(id),
     });
     // console.log('got image id', id);
     return {

--- a/types/directory.js
+++ b/types/directory.js
@@ -6,18 +6,10 @@ const metaversefileLoader = require('./metaversefile.js');
 
 const templateString = fs.readFileSync(path.join(__dirname, '..', 'type_templates', 'html.js'));
 
-/* const _jsonParse = s => {
-  try {
-    return JSON.parse(s);
-  } catch(err) {
-    return null;
-  }
-}; */
 const _resolveHtml = (id, importer) => {
   const code = fillTemplate(templateString, {
     srcUrl: id,
   });
-  // console.log('got glb id', id);
   return {
     code,
     map: null,

--- a/types/fog.js
+++ b/types/fog.js
@@ -11,7 +11,7 @@ module.exports = {
     id = createRelativeFromAbsolutePath(id);
     
     const code = fillTemplate(templateString, {
-      srcUrl: id,
+      srcUrl: JSON.stringify(id),
     });
     // console.log('got image id', id);
     return {

--- a/types/gif.js
+++ b/types/gif.js
@@ -11,7 +11,7 @@ module.exports = {
     id = createRelativeFromAbsolutePath(id);
     
     const code = fillTemplate(templateString, {
-      srcUrl: id,
+      srcUrl: JSON.stringify(id),
     });
     // console.log('got glb id', id);
     return {

--- a/types/glb.js
+++ b/types/glb.js
@@ -39,8 +39,9 @@ module.exports = {
         return [];
       }
     })();
+
     const code = fillTemplate(templateString, {
-      srcUrl: id,
+      srcUrl: JSON.stringify(id),
       components: JSON.stringify(components),
     });
     return {

--- a/types/glb.js
+++ b/types/glb.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const {fillTemplate, createRelativeFromAbsolutePath} = require('../util.js');
 
 const templateString = fs.readFileSync(path.join(__dirname, '..', 'type_templates', 'glb.js'), 'utf8');
-const cwd = process.cwd();
+// const cwd = process.cwd();
 
 function parseQuery(queryString) {
   const query = {};
@@ -20,16 +20,9 @@ function parseQuery(queryString) {
 }
 
 module.exports = {
-  /* resolveId(source, importer) {
-    console.log('resolve id', {source, importer});
-    // console.log('got GLB source!!!!!!!!!!!!', {source, importer});
-    return null;
-  }, */
   load(id) {
-    
     id = createRelativeFromAbsolutePath(id);
     
-    // console.log('got GLB id!!!!!!!!!!!!!!!!!', {id, match: id.match(/#([\s\S]+)$/)});
     const components = (() => {
       const match = id.match(/#([\s\S]+)$/);
       if (match) {

--- a/types/glbb.js
+++ b/types/glbb.js
@@ -10,9 +10,8 @@ module.exports = {
     
     id = createRelativeFromAbsolutePath(id);
 
-    // console.log('load glbb', id);
     const code = fillTemplate(templateString, {
-      srcUrl: id,
+      srcUrl: JSON.stringify(id),
     });
     return {
       code,

--- a/types/gltj.js
+++ b/types/gltj.js
@@ -3,16 +3,15 @@ const fs = require('fs');
 const {fillTemplate, createRelativeFromAbsolutePath} = require('../util.js');
 
 const templateString = fs.readFileSync(path.join(__dirname, '..', 'type_templates', 'gltj.js'), 'utf8');
-const cwd = process.cwd();
+// const cwd = process.cwd();
 
 module.exports = {
   load(id) {
 
     id = createRelativeFromAbsolutePath(id);
     
-    // console.log('load glbb', id);
     const code = fillTemplate(templateString, {
-      srcUrl: id,
+      srcUrl: JSON.stringify(id),
     });
     return {
       code,

--- a/types/group.js
+++ b/types/group.js
@@ -11,7 +11,7 @@ module.exports = {
     id = createRelativeFromAbsolutePath(id);
 
     const code = fillTemplate(templateString, {
-      srcUrl: id,
+      srcUrl: JSON.stringify(id),
     });
     // console.log('got image id', id);
     return {

--- a/types/html.js
+++ b/types/html.js
@@ -1,13 +1,11 @@
 const path = require('path');
 const fs = require('fs');
-const {fillTemplate, createRelativeFromAbsolutePath} = require('../util.js');
+const {jsonParse, fillTemplate, createRelativeFromAbsolutePath} = require('../util.js');
 
 const templateString = fs.readFileSync(path.join(__dirname, '..', 'type_templates', 'html.js'), 'utf8');
-// const cwd = process.cwd();
 
 module.exports = {
   load(id) {
-
     id = createRelativeFromAbsolutePath(id);
 
     let components = [];
@@ -27,7 +25,6 @@ module.exports = {
       srcUrl: JSON.stringify(id),
       components: JSON.stringify(components),
     });
-    // console.log('got glb id', id);
     return {
       code,
       map: null,

--- a/types/html.js
+++ b/types/html.js
@@ -10,15 +10,18 @@ module.exports = {
 
     id = createRelativeFromAbsolutePath(id);
 
-    const components = (() => {
+    let components = [];
+    (() => {
       const match = id.match(/#([\s\S]+)$/);
       if (match) {
-        const q = parseQuery(match[1]);
-        return q.components !== undefined ? JSON.parse(q.components) : [];
-      } else {
-        return [];
+        const q = new URLSearchParams(match[1]);
+        const qComponents = q.get('components');
+        if (qComponents !== undefined) {
+          components = jsonParse(qComponents) ?? [];
+        }
       }
     })();
+
     // console.log('load html', id, JSON.stringify(templateString, null, 2));
     const code = fillTemplate(templateString, {
       srcUrl: id,

--- a/types/html.js
+++ b/types/html.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const {fillTemplate, createRelativeFromAbsolutePath} = require('../util.js');
 
 const templateString = fs.readFileSync(path.join(__dirname, '..', 'type_templates', 'html.js'), 'utf8');
-const cwd = process.cwd();
+// const cwd = process.cwd();
 
 module.exports = {
   load(id) {

--- a/types/html.js
+++ b/types/html.js
@@ -24,7 +24,7 @@ module.exports = {
 
     // console.log('load html', id, JSON.stringify(templateString, null, 2));
     const code = fillTemplate(templateString, {
-      srcUrl: id,
+      srcUrl: JSON.stringify(id),
       components: JSON.stringify(components),
     });
     // console.log('got glb id', id);

--- a/types/image.js
+++ b/types/image.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const {fillTemplate, createRelativeFromAbsolutePath} = require('../util.js');
 
 const templateString = fs.readFileSync(path.join(__dirname, '..', 'type_templates', 'image.js'), 'utf8');
-const cwd = process.cwd();
+// const cwd = process.cwd();
 
 module.exports = {
   load(id) {
@@ -11,7 +11,7 @@ module.exports = {
     id = createRelativeFromAbsolutePath(id);
     
     const code = fillTemplate(templateString, {
-      srcUrl: id,
+      srcUrl: JSON.stringify(id),
     });
     console.log('got image id', id);
     return {

--- a/types/jsx.js
+++ b/types/jsx.js
@@ -4,7 +4,7 @@ const Babel = require('@babel/core');
 const fetch = require('node-fetch');
 const {jsonParse} = require('../util.js');
 
-function parseQuery(queryString) {
+/* function parseQuery(queryString) {
   const query = {};
   const pairs = (queryString[0] === '?' ? queryString.substr(1) : queryString).split('&');
   for (let i = 0; i < pairs.length; i++) {
@@ -16,7 +16,7 @@ function parseQuery(queryString) {
     }
   }
   return query;
-}
+} */
 
 module.exports = {
   async load(id) {
@@ -40,15 +40,18 @@ module.exports = {
     (() => {
       const match = id.match(/#([\s\S]+)$/);
       if (match) {
-        const q = parseQuery(match[1]);
-        if (q.name !== undefined) {
-          name = q.name;
+        const q = new URLSearchParams(match[1]);
+        const qName = q.get('name');
+        if (qName !== undefined) {
+          name = qName;
         }
-        if (q.description !== undefined) {
-          description = q.description;
+        const qDescription = q.get('description');
+        if (qDescription !== undefined) {
+          description = qDescription;
         }
-        if (q.components !== undefined) {
-          components = jsonParse(q.components) ?? [];
+        const qComponents = q.get('components');
+        if (qComponents !== undefined) {
+          components = jsonParse(qComponents) ?? [];
         }
       }
     })();

--- a/types/light.js
+++ b/types/light.js
@@ -11,7 +11,7 @@ module.exports = {
     id = createRelativeFromAbsolutePath(id);
     
     const code = fillTemplate(templateString, {
-      srcUrl: id,
+      srcUrl: JSON.stringify(id),
     });
     // console.log('got image id', id);
     return {

--- a/types/metaversefile.js
+++ b/types/metaversefile.js
@@ -1,10 +1,10 @@
 const path = require('path');
-const fs = require('fs');
+// const fs = require('fs');
 const url = require('url');
-const fetch = require('node-fetch');
+// const fetch = require('node-fetch');
 const {cwd, fetchFileFromId, createRelativeFromAbsolutePath} = require('../util.js');
 
-const _jsonParse = s => {
+const _jsonParse2 = s => {
   try {
     const result = JSON.parse(s);
     return {result};
@@ -25,7 +25,7 @@ module.exports = {
     const s = await fetchFileFromId(id, importer, 'utf8');
     // console.log('metaversefile fetch', {id, importer, s});
     if (s !== null) {
-      const {result, error} = _jsonParse(s);
+      const {result, error} = _jsonParse2(s);
       if (!error) {
         // console.log('load metaversefile', {s, result});
         const {name, description, start_url, components} = result;
@@ -104,19 +104,5 @@ module.exports = {
       console.warn('.metaversefile could not be loaded');
       return null;
     }
-    
-    /* const j = _jsonParse(src);
-    const start_url = j?.start_url;
-    if (typeof start_url === 'string') {
-      console.log('got id', {id, start_url});
-      const code = `console.log('got metaversefile');`;
-      return {
-        code,
-        map: null // provide source map if available
-      };
-    } else {
-      console.warn('.metaversefile has no "start_url": string');
-      return null;
-    } */
   }
 };

--- a/types/rendersettings.js
+++ b/types/rendersettings.js
@@ -3,7 +3,6 @@ const fs = require('fs');
 const {fillTemplate, createRelativeFromAbsolutePath} = require('../util.js');
 
 const templateString = fs.readFileSync(path.join(__dirname, '..', 'type_templates', 'rendersettings.js'), 'utf8');
-// const cwd = process.cwd();
 
 module.exports = {
   load(id) {
@@ -11,9 +10,8 @@ module.exports = {
     id = createRelativeFromAbsolutePath(id);
     
     const code = fillTemplate(templateString, {
-      srcUrl: id,
+      srcUrl: JSON.stringify(id),
     });
-    // console.log('got image id', id);
     return {
       code,
       map: null,

--- a/types/scn.js
+++ b/types/scn.js
@@ -3,7 +3,6 @@ const fs = require('fs');
 const {fillTemplate, createRelativeFromAbsolutePath} = require('../util.js');
 
 const templateString = fs.readFileSync(path.join(__dirname, '..', 'type_templates', 'scn.js'), 'utf8');
-// const cwd = process.cwd();
 
 module.exports = {
   
@@ -11,9 +10,8 @@ module.exports = {
 
     id = createRelativeFromAbsolutePath(id);
     
-    // console.log('got scn id', id);
     const code = fillTemplate(templateString, {
-      srcUrl: id,
+      srcUrl: JSON.stringify(id),
     });
     return {
       code,

--- a/types/spawnpoint.js
+++ b/types/spawnpoint.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const {fillTemplate, createRelativeFromAbsolutePath} = require('../util.js');
 
 const templateString = fs.readFileSync(path.join(__dirname, '..', 'type_templates', 'spawnpoint.js'), 'utf8');
-const cwd = process.cwd();
+// const cwd = process.cwd();
 
 module.exports = {
   load(id) {
@@ -11,9 +11,8 @@ module.exports = {
     id = createRelativeFromAbsolutePath(id);
     
     const code = fillTemplate(templateString, {
-      srcUrl: id,
+      srcUrl: JSON.stringify(id),
     });
-    // console.log('got image id', id);
     return {
       code,
       map: null,

--- a/types/text.js
+++ b/types/text.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const {fillTemplate, createRelativeFromAbsolutePath} = require('../util.js');
 
 const templateString = fs.readFileSync(path.join(__dirname, '..', 'type_templates', 'text.js'), 'utf8');
-const cwd = process.cwd();
+// const cwd = process.cwd();
 
 module.exports = {
   load(id) {
@@ -11,9 +11,8 @@ module.exports = {
     id = createRelativeFromAbsolutePath(id);
     
     const code = fillTemplate(templateString, {
-      srcUrl: id,
+      srcUrl: JSON.stringify(id),
     });
-    // console.log('got image id', id);
     return {
       code,
       map: null,

--- a/types/vox.js
+++ b/types/vox.js
@@ -3,16 +3,14 @@ const fs = require('fs');
 const {fillTemplate, createRelativeFromAbsolutePath} = require('../util.js');
 
 const templateString = fs.readFileSync(path.join(__dirname, '..', 'type_templates', 'vox.js'), 'utf8');
-const cwd = process.cwd();
+// const cwd = process.cwd();
 
 module.exports = {
   load(id) {
-
     id = createRelativeFromAbsolutePath(id);
     
-    // console.log('got glb id', id);
     const code = fillTemplate(templateString, {
-      srcUrl: id,
+      srcUrl: JSON.stringify(id),
     });
     return {
       code,

--- a/types/vrm.js
+++ b/types/vrm.js
@@ -3,39 +3,41 @@ const fs = require('fs');
 const {fillTemplate, createRelativeFromAbsolutePath} = require('../util.js');
 
 const templateString = fs.readFileSync(path.join(__dirname, '..', 'type_templates', 'vrm.js'), 'utf8');
-const cwd = process.cwd();
+// const cwd = process.cwd();
 
-function parseQuery(queryString) {
-    const query = {};
-    const pairs = (queryString[0] === '?' ? queryString.substr(1) : queryString).split('&');
-    for (let i = 0; i < pairs.length; i++) {
-      const pair = pairs[i].split('=');
-      const k = decodeURIComponent(pair[0]);
-      if (k) {
-        const v = decodeURIComponent(pair[1] || '');
-        query[k] = v;
-      }
+/* function parseQuery(queryString) {
+  const query = {};
+  const pairs = (queryString[0] === '?' ? queryString.substr(1) : queryString).split('&');
+  for (let i = 0; i < pairs.length; i++) {
+    const pair = pairs[i].split('=');
+    const k = decodeURIComponent(pair[0]);
+    if (k) {
+      const v = decodeURIComponent(pair[1] || '');
+      query[k] = v;
     }
-    return query;
   }
+  return query;
+} */
   
 module.exports = {
   load(id) {
-    
     id = createRelativeFromAbsolutePath(id);
 
-    const components = (() => {
-        const match = id.match(/#([\s\S]+)$/);
-        if (match) {
-          const q = parseQuery(match[1]);
-          return q.components !== undefined ? JSON.parse(q.components) : [];
-        } else {
-          return [];
+    let components = [];
+    (() => {
+      const match = id.match(/#([\s\S]+)$/);
+      if (match) {
+        const q = new URLSearchParams(match[1]);
+        const qComponents = q.get('components');
+        if (qComponents !== undefined) {
+          components = jsonParse(qComponents) ?? [];
         }
+      }
     })();
+
     const code = fillTemplate(templateString, {
-        srcUrl: id,
-        components: JSON.stringify(components),
+      srcUrl: JSON.stringify(id),
+      components: JSON.stringify(components),
     });
     return {
       code,

--- a/types/vrm.js
+++ b/types/vrm.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const fs = require('fs');
-const {fillTemplate, createRelativeFromAbsolutePath} = require('../util.js');
+const {jsonParse, fillTemplate, createRelativeFromAbsolutePath} = require('../util.js');
 
 const templateString = fs.readFileSync(path.join(__dirname, '..', 'type_templates', 'vrm.js'), 'utf8');
 // const cwd = process.cwd();


### PR DESCRIPTION
This PR fixes 2 subtle bugs with Totum loading:

1. Special characters in metadata (e.g. component string keys) were munged by not being put through a safe stringification first. We now should be passing all hashed components as JSON.
2. Some type handlers were using an old query parsing method which did not safely handle some characters. Now we use URLSearchParams to parse it per spec (it's `node`-native);