### PR TITLE
physics geometries get toggled with bone updates

### DIFF
--- a/type_templates/vrm.js
+++ b/type_templates/vrm.js
@@ -169,10 +169,22 @@ export default e => {
     });
 
     if (update) {
+
+      for (const physicsId of physicsIds) {
+        physics.disableGeometry(physicsId);
+        physics.disableGeometryQueries(physicsId);
+      }
+
       app.position.set(0, 0, 0);
       app.quaternion.identity();
       app.scale.set(1, 1, 1);
       app.updateMatrixWorld();
+    } else {
+      
+      for (const physicsId of physicsIds) {
+        physics.enableGeometry(physicsId);
+        physics.enableGeometryQueries(physicsId);
+      }
     }
 
   }


### PR DESCRIPTION
This corrects an "invisible" object appearing in front of you when spawning, that interacting with causes your avatar to be removed from the scene.  This seems to work locally, but looking for insight on the following before this get's merged:

- is it correct that the reason why the physics geometry is removed when you toggle vrm bone updates(formerly toggling if the mesh is skinned or not), is because characterPhysics from character-controller.js takes over?  and vice-versa when you'd untoggle bones(previously unskin)?


If the above is correct, this should be good to merge.  If not, I'll put this into draft and address any other points.  Closes #80 