### PR TITLE
Data url imports

### DIFF
--- a/plugins/rollup.js
+++ b/plugins/rollup.js
@@ -151,8 +151,6 @@ module.exports = function metaversefilePlugin() {
     name: 'metaversefile',
     enforce: 'pre',
     async resolveId(source, importer) {
-      // console.log('resolve id', source, importer);
-
       // do not resolve node module subpaths
       {
         if (/^((?:@[^\/]+\/)?[^\/:\.][^\/:]*)(\/[\s\S]*)$/.test(source)) {
@@ -210,35 +208,33 @@ module.exports = function metaversefilePlugin() {
       const type = _getType(source);
       const loader = loaders[type];
       const resolveId = loader?.resolveId;
-      // console.log('get type', {source, type, loader: !!loader, resolveId: !!resolveId});
       if (resolveId) {
         const source2 = await resolveId(source, importer);
         // console.log('resolve rewrite', {type, source, source2});
-        return source2;
+        if (source2 !== undefined) {
+          return source2;
+        }
+      }
+      if (replaced) {
+        // console.log('resolve replace', source);
+        return source;
       } else {
-        if (replaced) {
-          // console.log('resolve replace', source);
-          return source;
-        } else {
-          if (/^https?:\/\//.test(importer)) {
-            o = url.parse(importer);
-            if (/\/$/.test(o.pathname)) {
-              o.pathname += '.fakeFile';
-            }
-            o.pathname = _resolvePathName(o.pathname,source);
-            s = '/@proxy/' + url.format(o);
-            // console.log('resolve format', s);
-            return s;
-          } else {
-            // console.log('resolve null');
-            return null;
+        if (/^https?:\/\//.test(importer)) {
+          o = url.parse(importer);
+          if (/\/$/.test(o.pathname)) {
+            o.pathname += '.fakeFile';
           }
+          o.pathname = _resolvePathName(o.pathname,source);
+          s = '/@proxy/' + url.format(o);
+          // console.log('resolve format', s);
+          return s;
+        } else {
+          // console.log('resolve null');
+          return null;
         }
       }
     },
     async load(id) {
-      // console.log('load id', {id});
-      
       id = id
         // .replace(/^\/@proxy\//, '')
         .replace(/^(eth:\/(?!\/))/, '$1/')

--- a/types/jsx.js
+++ b/types/jsx.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const fs = require('fs');
 const url = require('url');
 const Babel = require('@babel/core');
@@ -6,8 +7,16 @@ const dataUrls = require('data-urls');
 const {parseIdHash} = require('../util.js');
 
 const textDecoder = new TextDecoder();
+const cwd = process.cwd();
 
 module.exports = {
+  async resolveId(source, importer) {
+    if (/^\.\//.test(source) && /^data:/.test(importer)) {
+      return path.join(cwd, source);
+    } else {
+      return undefined;
+    }
+  },
   async load(id) {
     let src;
     if (/https?:/i.test(id)) {


### PR DESCRIPTION
Supports rewriting imports from `data:` urls to be local references instead.

This lets us write `metaversefile.import('data:application/javascript,import lol from "./lol.js"; ...')`, allowing data url imports to be treated like any other module.

This is most useful in the `OffscreenEngine` worker case, where we need to synthesize and dynamically compile a module we are importing.