### PR TITLE
Double-encode scn content

### DIFF
--- a/type_templates/scn.js
+++ b/type_templates/scn.js
@@ -13,7 +13,7 @@ function getObjectUrl(object) {
     if (typeof content === 'object') {
       content = JSON.stringify(content);
     }
-    u = '/@proxy/data:' + type + ',' + encodeURI(content);
+    u = '/@proxy/' + encodeURI('data:' + type + ',' + encodeURI(content));
   } else {
     throw new Error('invalid scene object: ' + JSON.stringify(object));
   }


### PR DESCRIPTION
Fixes a URL marshalling bug where spaces in `scn` inline `content` JSON are eaten.

This was due to one layer of encoding being peeled by totum, leaving the remaining `data:` url bare. `fetch` would then mis-parse this `data:` URL (raw spaces are eaten by `fetch`).

This is is fixed by double-encoding the URL.