### PR TITLE
readd useFrame

### DIFF
--- a/type_templates/vrm.js
+++ b/type_templates/vrm.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import metaversefile from 'metaversefile';
 import { VRMMaterialImporter } from '@pixiv/three-vrm/lib/three-vrm.module';
-const { useApp, useLoaders, usePhysics, useCleanup, useActivate, useLocalPlayer } = metaversefile;
+const { useApp, useLoaders, usePhysics, useCleanup, useActivate, useLocalPlayer, useRemotePlayers, useFrame } = metaversefile;
 
 const localVector = new THREE.Vector3();
 const localVector2 = new THREE.Vector3();
@@ -83,7 +83,7 @@ export default e => {
 
   app.appType = 'vrm';
 
-  const srcUrl = ${this.srcUrl};
+  const srcUrl = ${ this.srcUrl };
 
   let arrayBuffer = null;
   const _cloneVrm = async () => {
@@ -143,6 +143,29 @@ export default e => {
       };
     }
   })());
+
+
+  useFrame(({ timestamp, timeDiff }) => {
+
+    let currentPlayer;
+    currentPlayer = app === useLocalPlayer().avatar?.app ?
+      useLocalPlayer() :
+      useRemotePlayers().find(element => {
+        return element.avatar.app === app;
+      });
+
+    if (!currentPlayer) {
+      // console.log('not a player');
+      return;
+    }
+
+    if (currentPlayer.isLocalPlayer && physics.getPhysicsEnabled()) {
+      physics.simulatePhysics(timeDiff);
+      currentPlayer.updatePhysics(timestamp, timeDiff);
+    }
+
+    currentPlayer.updateAvatar(timestamp, timeDiff);
+  });
 
   useActivate(() => {
     activateCb && activateCb();


### PR DESCRIPTION
PR #86 was reverted because of reference issues in the app repo. this readds the useFrame code

This PR has the vrm template take control of running updates, rather than calling them from the webaverse file.  some things to check when testing:
- character should not be in t-pose
- all animations should run at their correct speeds

should be tested with https://github.com/webaverse/app/pull/2646 otherwise the update calls will be run multiple times, causing animations to run too quickly.
