### PR TITLE
Do not auto-wear glbs

### DIFF
--- a/type_templates/glb.js
+++ b/type_templates/glb.js
@@ -243,7 +243,6 @@ export default e => {
       
       activateCb = () => {
         if (
-          // app.getComponent('wear') ||
           app.getComponent('sit')
         ) {
           app.wear();

--- a/type_templates/glb.js
+++ b/type_templates/glb.js
@@ -243,7 +243,7 @@ export default e => {
       
       activateCb = () => {
         if (
-          app.getComponent('wear') ||
+          // app.getComponent('wear') ||
           app.getComponent('sit')
         ) {
           app.wear();


### PR DESCRIPTION
Do not auto-wear in the GLB type template just because there is a wear component. This is handled per-component now instead.