### PR TITLE
Export app type from modules

### DIFF
--- a/contract_templates/cryptovoxels.js
+++ b/contract_templates/cryptovoxels.js
@@ -677,4 +677,5 @@ export default () => {
 export const contentId = ${this.contentId};
 export const name = ${this.name};
 export const description = ${this.description};
+export const type = 'js';
 export const components = ${this.components};

--- a/contract_templates/loomlock.js
+++ b/contract_templates/loomlock.js
@@ -614,4 +614,5 @@ export default e => {
 export const contentId = ${this.contentId};
 export const name = ${this.name};
 export const description = ${this.description};
+export const type = 'js';
 export const components = ${this.components};

--- a/contract_templates/moreloot.js
+++ b/contract_templates/moreloot.js
@@ -458,4 +458,5 @@ export default e => {
 export const contentId = ${this.contentId};
 export const name = ${this.name};
 export const description = ${this.description};
+export const type = 'js';
 export const components = ${this.components};

--- a/type_templates/background.js
+++ b/type_templates/background.js
@@ -4,8 +4,6 @@ const {useApp, useFrame, useCleanup, useInternals} = metaversefile;
 
 export default e => {
   const app = useApp();
-  app.appType = 'background';
-  
   const {scene} = useInternals();
 
   const srcUrl = ${this.srcUrl};
@@ -32,4 +30,5 @@ export default e => {
 export const contentId = ${this.contentId};
 export const name = ${this.name};
 export const description = ${this.description};
+export const type = 'background';
 export const components = ${this.components};

--- a/type_templates/fog.js
+++ b/type_templates/fog.js
@@ -6,8 +6,6 @@ export default e => {
   const app = useApp();
   const {rootScene} = useInternals();
 
-  app.appType = 'fog';
-
   const srcUrl = ${this.srcUrl};
   const mode = app.getComponent('mode') ?? 'attached';
 
@@ -42,4 +40,5 @@ export default e => {
 export const contentId = ${this.contentId};
 export const name = ${this.name};
 export const description = ${this.description};
+export const type = 'fog';
 export const components = ${this.components};

--- a/type_templates/gif.js
+++ b/type_templates/gif.js
@@ -12,13 +12,12 @@ const flipGeomeryUvs = geometry => {
 
 export default e => {
   const app = useApp();
-  app.appType = 'gif';
-  app.gif = null;
-  
   const {gifLoader} = useLoaders();
   const physics = usePhysics();
   
   const srcUrl = ${this.srcUrl};
+
+  app.gif = null;
   
   const geometry = new THREE.PlaneBufferGeometry(1, 1);
   /* geometry.boundingBox = new THREE.Box3(
@@ -103,4 +102,5 @@ export default e => {
 export const contentId = ${this.contentId};
 export const name = ${this.name};
 export const description = ${this.description};
+export const type = 'gif';
 export const components = ${this.components};

--- a/type_templates/glb.js
+++ b/type_templates/glb.js
@@ -17,7 +17,6 @@ const localMatrix = new THREE.Matrix4(); */
 
 export default e => {
   const app = useApp();
-  app.appType = 'glb';
   
   const physics = usePhysics();
   const localPlayer = useLocalPlayer();
@@ -330,4 +329,5 @@ export default e => {
 export const contentId = ${this.contentId};
 export const name = ${this.name};
 export const description = ${this.description};
+export const type = 'glb';
 export const components = ${this.components};

--- a/type_templates/glbb.js
+++ b/type_templates/glbb.js
@@ -7,8 +7,6 @@ const worldSize = 2;
 
 export default () => {
   const app = useApp();
-  app.appType = 'glbb';
-  
   const physics = usePhysics();
   
   const o = new THREE.Object3D();
@@ -63,4 +61,5 @@ export default () => {
 export const contentId = ${this.contentId};
 export const name = ${this.name};
 export const description = ${this.description};
+export const type = 'glbb';
 export const components = ${this.components};

--- a/type_templates/gltj.js
+++ b/type_templates/gltj.js
@@ -8,7 +8,6 @@ const geometry = new THREE.PlaneBufferGeometry(2, 2);
 
 export default e => {
   const app = useApp();
-  app.appType = 'gltj';
 
   const srcUrl = ${this.srcUrl};
 
@@ -64,4 +63,5 @@ export default e => {
 export const contentId = ${this.contentId};
 export const name = ${this.name};
 export const description = ${this.description};
+export const type = 'gltj';
 export const components = ${this.components};

--- a/type_templates/group.js
+++ b/type_templates/group.js
@@ -24,9 +24,6 @@ function getObjectUrl(object) {
 
 export default e => {
   const app = useApp();
-  app.appType = 'group';
-  
-  // console.log('group load', app, app.position.toArray());
 
   const srcUrl = ${this.srcUrl};
   
@@ -158,4 +155,5 @@ export default e => {
 export const contentId = ${this.contentId};
 export const name = ${this.name};
 export const description = ${this.description};
+export const type = 'group';
 export const components = ${this.components};

--- a/type_templates/html.js
+++ b/type_templates/html.js
@@ -38,10 +38,9 @@ class IFrameMesh extends THREE.Mesh {
 
 export default e => {
   const app = useApp();
-  app.appType = 'html';
+  const physics = usePhysics();
   
   const object = app;
-  const physics = usePhysics();
   const {
     sceneHighPriority,
     camera,
@@ -243,4 +242,5 @@ export default e => {
 export const contentId = ${this.contentId};
 export const name = ${this.name};
 export const description = ${this.description};
+export const type = 'html';
 export const components = ${this.components};

--- a/type_templates/image.js
+++ b/type_templates/image.js
@@ -13,11 +13,10 @@ const {useApp, useFrame, useCleanup, usePhysics} = metaversefile;
 
 export default e => {
   const app = useApp();
-  app.appType = 'image';
-  app.image = null;
-  
   // const {gifLoader} = useLoaders();
   const physics = usePhysics();
+
+  app.image = null;
 
   const srcUrl = ${this.srcUrl};
   // console.log('got gif 1');
@@ -113,4 +112,5 @@ export default e => {
 export const contentId = ${this.contentId};
 export const name = ${this.name};
 export const description = ${this.description};
+export const type = 'image';
 export const components = ${this.components};

--- a/type_templates/light.js
+++ b/type_templates/light.js
@@ -7,13 +7,12 @@ const localVector2 = new THREE.Vector3();
 
 export default e => {
   const app = useApp();
-  const worldLights = app;
-
-  app.appType = 'light';
-  app.light = null;
 
   const srcUrl = ${this.srcUrl};
   
+  const worldLights = app;
+  app.light = null;
+
   const addShadows = (light, params) => {
     light.castShadow = true; 
     if (typeof params[1] === 'number') {
@@ -203,4 +202,5 @@ export default e => {
 export const contentId = ${this.contentId};
 export const name = ${this.name};
 export const description = ${this.description};
+export const type = 'light';
 export const components = ${this.components};

--- a/type_templates/lore.js
+++ b/type_templates/lore.js
@@ -4,8 +4,6 @@ const {useApp, useLoreAIScene, useCleanup} = metaversefile;
 
 export default e => {
   const app = useApp();
-  app.appType = 'lore';
-
   const loreAIScene = useLoreAIScene();
 
   const srcUrl = ${this.srcUrl};
@@ -40,4 +38,5 @@ export default e => {
 export const contentId = ${this.contentId};
 export const name = ${this.name};
 export const description = ${this.description};
+export const type = 'lore';
 export const components = ${this.components};

--- a/type_templates/quest.js
+++ b/type_templates/quest.js
@@ -11,8 +11,6 @@ export default e => {
   const defaultModules = useDefaultModules();
   const questManager = useQuests();
 
-  app.appType = 'quest';
-
   const srcUrl = ${this.srcUrl};
 
   const _makeAreaApp = ({
@@ -116,4 +114,5 @@ export default e => {
 export const contentId = ${this.contentId};
 export const name = ${this.name};
 export const description = ${this.description};
+export const type = 'quest';
 export const components = ${this.components};

--- a/type_templates/rendersettings.js
+++ b/type_templates/rendersettings.js
@@ -6,8 +6,6 @@ export default e => {
   const app = useApp();
   const renderSettings = useRenderSettings();
 
-  app.appType = 'rendersettings';
-
   const srcUrl = ${this.srcUrl};
 
   let live = true;
@@ -33,4 +31,5 @@ export default e => {
 export const contentId = ${this.contentId};
 export const name = ${this.name};
 export const description = ${this.description};
+export const type = 'rendersettings';
 export const components = ${this.components};

--- a/type_templates/scn.js
+++ b/type_templates/scn.js
@@ -46,10 +46,9 @@ function mergeComponents(a, b) {
 
 export default e => {
   const app = useApp();
-
-  app.appType = 'scn';
   
   const srcUrl = ${this.srcUrl};
+  
   const mode = app.getComponent('mode') ?? 'attached';
   const paused = app.getComponent('paused') ?? false;
   const objectComponents = app.getComponent('objectComponents') ?? [];
@@ -151,4 +150,5 @@ export default e => {
 export const contentId = ${this.contentId};
 export const name = ${this.name};
 export const description = ${this.description};
+export const type = 'scn';
 export const components = ${this.components};

--- a/type_templates/spawnpoint.js
+++ b/type_templates/spawnpoint.js
@@ -6,7 +6,6 @@ const localEuler = new THREE.Euler(0, 0, 0, 'YXZ');
 
 export default e => {
   const app = useApp();
-  app.appType = 'spawnpoint';
   
   const srcUrl = ${this.srcUrl};
   const mode = app.getComponent('mode') ?? 'attached';
@@ -58,4 +57,5 @@ export default e => {
 export const contentId = ${this.contentId};
 export const name = ${this.name};
 export const description = ${this.description};
+export const type = 'spawnpoint';
 export const components = ${this.components};

--- a/type_templates/text.js
+++ b/type_templates/text.js
@@ -27,11 +27,11 @@ async function makeTextMesh(
 
 export default e => {
   const app = useApp();
-  app.appType = 'text';
-  app.text = null;
   
   const srcUrl = ${this.srcUrl};
   
+  app.text = null;
+
   e.waitUntil((async () => {
     const res = await fetch(srcUrl);
     const j = await res.json();
@@ -46,4 +46,5 @@ export default e => {
 export const contentId = ${this.contentId};
 export const name = ${this.name};
 export const description = ${this.description};
+export const type = 'text';
 export const components = ${this.components};

--- a/type_templates/vox.js
+++ b/type_templates/vox.js
@@ -5,13 +5,11 @@ const {useApp, useFrame, useCleanup, useLoaders, usePhysics} = metaversefile;
 
 export default e => {
   const app = useApp();
-  app.appType = 'vox';
-  
-  const root = app;
-  
   const physics = usePhysics();
 
   const srcUrl = ${this.srcUrl};
+
+  const root = app;
 
   const physicsIds = [];
   const staticPhysicsIds = [];
@@ -95,4 +93,5 @@ export default e => {
 export const contentId = ${this.contentId};
 export const name = ${this.name};
 export const description = ${this.description};
+export const type = 'vox';
 export const components = ${this.components};

--- a/type_templates/vrm.js
+++ b/type_templates/vrm.js
@@ -18,37 +18,10 @@ const _fetchArrayBuffer = async srcUrl => {
     throw new Error('failed to load: ' + res.status + ' ' + srcUrl);
   }
 };
-/* const loadVrm = async (srcUrl) => {
-  let vrmObject;
-  try {
-    const res = await fetch(srcUrl);
-    if (res.ok) {
-      const arrayBuffer = await res.arrayBuffer();
-      vrmObject = await parseVrm(arrayBuffer, srcUrl);
-      vrmObject.arrayBuffer = arrayBuffer;
-      // startMonetization(instanceId, monetizationPointer, ownerAddress);
-    } else {
-      throw new Error('failed to load: ' + res.status + ' ' + srcUrl);
-    }
-  } catch(err) {
-    console.warn(err);
-    vrmObject = null;
-  }
-  return vrmObject;
-}; */
 const parseVrm = (arrayBuffer, srcUrl) => new Promise((accept, reject) => {
   const { gltfLoader } = useLoaders();
   gltfLoader.parse(arrayBuffer, srcUrl, accept, reject);
 });
-/* const _findMaterialsObjects = (o, name) => {
-  const result = [];
-  o.traverse(o => {
-    if (o.isMesh && o.material.name === name) {
-      result.push(o);
-    }
-  });
-  return result;
-}; */
 const _toonShaderify = async o => {
   await new VRMMaterialImporter().convertGLTFMaterials(o);
 };

--- a/type_templates/vrm.js
+++ b/type_templates/vrm.js
@@ -54,8 +54,6 @@ export default e => {
   const app = useApp();
   const physics = usePhysics();
 
-  app.appType = 'vrm';
-
   const srcUrl = ${this.srcUrl};
 
   let arrayBuffer = null;

--- a/type_templates/vrm.js
+++ b/type_templates/vrm.js
@@ -64,7 +64,6 @@ export default e => {
   };
 
   const _prepVrm = (vrm) => {
-    //vrm.visible = false; //will need later
     app.add(vrm);
     vrm.updateMatrixWorld();
     _addAnisotropy(vrm, 16);
@@ -132,8 +131,9 @@ export default e => {
   app.toggleBoneUpdates = update => {
     const scene = app.skinnedVrm.scene;
     scene.traverse(o => {
-      // o.matrixAutoUpdate = update;
-      if (o.isBone) o.matrixAutoUpdate = update;
+      if (o.isBone) {
+        o.matrixAutoUpdate = update;
+      }
     });
 
     if (update) {

--- a/type_templates/vrm.js
+++ b/type_templates/vrm.js
@@ -194,7 +194,8 @@ export default e => {
 
   return app;
 };
-export const contentId = ${ this.contentId };
-export const name = ${ this.name };
-export const description = ${ this.description };
-export const components = ${ this.components };
+export const contentId = ${this.contentId};
+export const name = ${this.name};
+export const description = ${this.description};
+export const type = 'vrm';
+export const components = ${this.components};

--- a/types/jsx.js
+++ b/types/jsx.js
@@ -57,6 +57,7 @@ module.exports = {
 export const contentId = ${JSON.stringify(contentId)};
 export const name = ${JSON.stringify(name)};
 export const description = ${JSON.stringify(description)};
+export const type = 'js';
 export const components = ${JSON.stringify(components)};
 `;
     return {


### PR DESCRIPTION
Exports the `type` property in all `totum` type templates. Previously this was attached to the `app` object by each type template initialization method.

This change lets the parent code parse the app type much more easily, without requiring instantiating apps. This is especially useful for generating previews and gathering module metadata.