### PR TITLE
FIX: Clean comment on html.js

### DIFF
--- a/type_templates/html.js
+++ b/type_templates/html.js
@@ -99,7 +99,6 @@ export default e => {
 
   function epsilon(value) {
     return value;
-    // return Math.abs(value) < 1e-10 ? 0 : value;
   }
   function getObjectCSSMatrix( matrix, cameraCSSMatrix ) {
     var elements = matrix.elements;


### PR DESCRIPTION
Cleaning up the comment that was breaking when running the build command: 
`// return Math.abs(value) < 1e-10 ? 0 : value;`