### PR TITLE
Set bone to name in action instead of entire bone to prevent buffer overflow

### DIFF
--- a/type_templates/glb.js
+++ b/type_templates/glb.js
@@ -271,7 +271,7 @@ export default e => {
           const {instanceId} = app;
           const localPlayer = useLocalPlayer();
 
-          const rideBone = sitSpec.sitBone ? rideMesh.skeleton.bones.find(bone => bone.name === sitSpec.sitBone) : null;
+          const rideBone = sitSpec.sitBone ? rideMesh.skeleton.bones.find(bone => bone.name === sitSpec.sitBone).name : null;
           const sitAction = {
             type: 'sit',
             time: 0,


### PR DESCRIPTION
Right now when trying to mount the dragon, there is a buffer overflow error because wsrtc is trying to serialize the entire bone. We really just want the bone name, I think, and indeed these seems to work alright for us in the app.