### PR TITLE
Scn type template fix percent encoding

### DIFF
--- a/type_templates/scn.js
+++ b/type_templates/scn.js
@@ -13,7 +13,8 @@ function getObjectUrl(object) {
     if (typeof content === 'object') {
       content = JSON.stringify(content);
     }
-    u = '/@proxy/' + encodeURI('data:' + type + ',' + encodeURI(content));
+    const dataUrlPrefix = 'data:' + type + ',';
+    u = '/@proxy/' + dataUrlPrefix + encodeURIComponent(content).replace(/\%/g, '%25')//.replace(/\\//g, '%2F');
   } else {
     throw new Error('invalid scene object: ' + JSON.stringify(object));
   }


### PR DESCRIPTION
`encodeURI` -> `encodeURIComponent` fixes incorrect (lack of) encoding `/`, which was causing problems during URL parse which chops `//` from `https://`.