### PR TITLE
Remove isMesh check for animation, fix GLB animations

### DIFF
--- a/type_templates/glb.js
+++ b/type_templates/glb.js
@@ -79,7 +79,7 @@ export default e => {
           const animationEnabled = !!(app.getComponent('animation') ?? true);
           if (animationEnabled) {
             o.traverse(o => {
-              if (o.isMesh) {
+              // if (o.isMesh) {
                 const idleAnimation = animations.find(a => a.name === 'idle');
                 let clip = idleAnimation || animations[animationMixers.length];
                 if (clip) {
@@ -90,7 +90,7 @@ export default e => {
 
                   animationMixers.push(mixer);
                 }
-              }
+              // }
             });
           }
         };


### PR DESCRIPTION
Right now, certain GLB files don't have animation playing properly. This seems to be when the animation is on an empty that the loader interprets as a group or other non-mesh object.

This skips the isMesh check and seems to immediately fix broken GLBs with no errors.