### PR TITLE
Add scene settings

### DIFF
--- a/plugins/rollup.js
+++ b/plugins/rollup.js
@@ -35,6 +35,7 @@ const light = require('../types/light.js');
 const text = require('../types/text.js');
 //const fog = require('../types/fog.js');
 // const background = require('../types/background.js');
+const scenesettings = require('../types/scenesettings.js');
 const rendersettings = require('../types/rendersettings.js');
 const spawnpoint = require('../types/spawnpoint.js');
 const wind = require('../types/wind.js');
@@ -66,6 +67,7 @@ const loaders = {
   // fog,
   // background,
   rendersettings,
+  scenesettings,
   spawnpoint,
   lore,
   quest,
@@ -92,7 +94,7 @@ const _getType = id => {
     }
     let extension;
     let match2;
-    if (match2 = type.match(/^application\/(light|text|rendersettings|spawnpoint|lore|quest|npc|mob|react|group|wind)$/)) {
+    if (match2 = type.match(/^application\/(light|text|rendersettings|scenesettings|spawnpoint|lore|quest|npc|mob|react|group|wind)$/)) {
       extension = match2[1];
     } else if (match2 = type.match(/^application\/(javascript)$/)) {
       extension = 'js';

--- a/type_templates/scenesettings.js
+++ b/type_templates/scenesettings.js
@@ -1,0 +1,39 @@
+// import * as THREE from 'three';
+import metaversefile from 'metaversefile';
+const {useApp, useSceneSettingsManager, useCleanup} = metaversefile;
+
+export default e => {
+  const app = useApp();
+  console.log('creating scene settings app');
+  const sceneSettings = useSceneSettingsManager();
+
+  console.log('sceneSettings', sceneSettings)
+
+  const srcUrl = ${this.srcUrl};
+
+  let live = true;
+  let json = null;
+  let localSceneSettings = null;
+  (async () => {
+    const res = await fetch(srcUrl);
+    if (!live) return;
+    json = await res.json();
+    console.log('json is', json)
+    if (!live) return;
+    localSceneSettings = sceneSettings.makeSceneSettings(json);
+  })();
+  
+  useCleanup(() => {
+    live = false;
+    localSceneSettings = null;
+  });
+
+  app.getSceneSettings = () => localSceneSettings;
+
+  return app;
+};
+export const contentId = ${this.contentId};
+export const name = ${this.name};
+export const description = ${this.description};
+export const type = 'scenesettings';
+export const components = ${this.components};

--- a/types/scenesettings.js
+++ b/types/scenesettings.js
@@ -1,0 +1,32 @@
+const path = require('path');
+const fs = require('fs');
+const {fillTemplate, createRelativeFromAbsolutePath, parseIdHash} = require('metaversefile/util.js');
+
+const templateString = fs.readFileSync(path.join(__dirname, '..', 'type_templates', 'scenesettings.js'), 'utf8');
+
+module.exports = {
+  load(id) {
+
+    id = createRelativeFromAbsolutePath(id);
+
+    const {
+      contentId,
+      name,
+      description,
+      components,
+    } = parseIdHash(id);
+    
+    const code = fillTemplate(templateString, {
+      srcUrl: JSON.stringify(id),
+      contentId: JSON.stringify(contentId),
+      name: JSON.stringify(name),
+      description: JSON.stringify(description),
+      components: JSON.stringify(components),
+    });
+    console.log('code is', code);
+    return {
+      code,
+      map: null,
+    };
+  },
+};


### PR DESCRIPTION
This PR adds a scene settings app, which can override flying and naruto run. If scenes don't have this app then the default settings are used.

I could imagine a lot of other features that devs might want (allowMagic, allowTeleporting, respawnIfBelowHeight, etc)