### PR TITLE
Bugfix GLB animations playing

### DIFF
--- a/type_templates/glb.js
+++ b/type_templates/glb.js
@@ -78,20 +78,16 @@ export default e => {
         const _loadAnimations = () => {
           const animationEnabled = !!(app.getComponent('animation') ?? true);
           if (animationEnabled) {
-            o.traverse(o => {
-              // if (o.isMesh) {
-                const idleAnimation = animations.find(a => a.name === 'idle');
-                let clip = idleAnimation || animations[animationMixers.length];
-                if (clip) {
-                  const mixer = new THREE.AnimationMixer(o);
-                  
-                  const action = mixer.clipAction(clip);
-                  action.play();
+            const idleAnimation = animations.find(a => a.name === 'idle');
+            const clips = idleAnimation ? [idleAnimation] : animations;
+            for (const clip of clips) {
+              const mixer = new THREE.AnimationMixer(o);
+              
+              const action = mixer.clipAction(clip);
+              action.play();
 
-                  animationMixers.push(mixer);
-                }
-              // }
-            });
+              animationMixers.push(mixer);
+            }
           }
         };
         const petComponent = app.getComponent('pet');


### PR DESCRIPTION
Before, in the GLB totum type template, we would iterate the tree and pluck one animation per node, which doesn't make much sense.

Instead this PR makes it so if there is no idle animation, all animations will play.