### PR TITLE
[WIP] - suggestion: single animation mixer

### DIFF
--- a/type_templates/glb.js
+++ b/type_templates/glb.js
@@ -84,8 +84,11 @@ export default e => {
             for (let i =0 ; i < animations.length; i++){
               actions.push(mixer.clipAction(animations[i]));
             }
-            const idleAction = actions.filter(a => a._clip.name.toLowerCase() === 'idle')[0] || actions[0];
-            idleAction.play();
+            const act = actions.filter(a => a._clip.name.toLowerCase() === 'idle')[0];
+            const idleAction = act ? [act] : actions;
+            for (let i =0 ; i < idleAction.length; i++){
+              idleAction[i].play();
+            }
           }
 
         };

--- a/type_templates/glb.js
+++ b/type_templates/glb.js
@@ -15,6 +15,7 @@ const localMatrix = new THREE.Matrix4(); */
 
 // const z180Quaternion = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 1, 0), Math.PI);
 
+
 export default e => {
   const app = useApp();
   
@@ -29,6 +30,7 @@ export default e => {
   app.glb = null;
   let mixer = null;
   const actions = [];
+  let currentActions = [];
   const uvScrolls = [];
   const physicsIds = [];
   app.physicsIds = physicsIds;
@@ -84,10 +86,10 @@ export default e => {
             for (let i =0 ; i < animations.length; i++){
               actions.push(mixer.clipAction(animations[i]));
             }
-            const act = actions.filter(a => a._clip.name.toLowerCase() === 'idle')[0];
-            const idleAction = act ? [act] : actions;
-            for (let i =0 ; i < idleAction.length; i++){
-              idleAction[i].play();
+            const idleAction = _getActions(['idle']);
+            currentActions = idleAction.length > 0 ? idleAction : actions;
+            for (let i =0 ; i < currentActions.length; i++){
+              currentActions[i].play();
             }
           }
 
@@ -252,6 +254,16 @@ export default e => {
       }
     }
   };
+  const _getActions = (actionStrings) => {
+    const result = [];
+    if (actionStrings.length){
+      for (let i =0; i < actionStrings.length ; i++){
+        const act = actions.filter(a => a._clip.name.toLowerCase() === actionStrings[i])[0];
+        if (act) result.push(act); 
+      }
+    }
+    return result;
+  }
   app.addEventListener('wearupdate', e => {
     if (e.wear) {
       if (app.glb) {
@@ -320,6 +332,12 @@ export default e => {
       mixer = null;
     }
   };
+
+  app.playClips = (clips, time) => {
+    if (mixer){
+
+    }
+  }
   
   return app;
 };

--- a/type_templates/glb.js
+++ b/type_templates/glb.js
@@ -256,13 +256,15 @@ export default e => {
   };
   const _getActions = (actionStrings) => {
     const result = [];
-    actionStrings = actionStrings.length ? actionStrings : [actionStrings];
+    actionStrings = Array.isArray(actionStrings) ? actionStrings : [actionStrings];
     for (let i =0; i < actionStrings.length ; i++){
-      if (actionStrings[i]){
+      if (typeof actionStrings[i] === "string"){
         const act = actions.filter(a => a._clip.name.toLowerCase() === actionStrings[i].toLowerCase())[0];
         if (act) result.push(act); 
       }
     }
+    if (result.length === 0)
+      console.warn("No animations found");
     return result;
   }
   app.addEventListener('wearupdate', e => {
@@ -337,7 +339,6 @@ export default e => {
   app.playAnimations = (animationStrings, transitionTime = 0.1) => {
     if (mixer){
       const nextActions = animationStrings ? _getActions(animationStrings) : actions;
-      console.log(nextActions)
       for (let i =0 ; i < currentActions.length; i++){
         currentActions[i].fadeOut(transitionTime);
       }

--- a/type_templates/glb.js
+++ b/type_templates/glb.js
@@ -256,10 +256,13 @@ export default e => {
   };
   const _getActions = (actionStrings) => {
     const result = [];
+    actionStrings = actionStrings.length ? actionStrings :[actionStrings]
     if (actionStrings.length){
       for (let i =0; i < actionStrings.length ; i++){
-        const act = actions.filter(a => a._clip.name.toLowerCase() === actionStrings[i])[0];
-        if (act) result.push(act); 
+        if (actionStrings[i]){
+          const act = actions.filter(a => a._clip.name.toLowerCase() === actionStrings[i].toLowerCase())[0];
+          if (act) result.push(act); 
+        }
       }
     }
     return result;
@@ -333,9 +336,19 @@ export default e => {
     }
   };
 
-  app.playClips = (clips, time) => {
+  app.playAnimations = (animationStrings, transitionTime = 0.1) => {
     if (mixer){
-
+      const nextActions = animationStrings ? _getActions(animationStrings) : actions;
+      console.log(nextActions)
+      for (let i =0 ; i < currentActions.length; i++){
+        currentActions[i].fadeOut(transitionTime);
+      }
+      for (let i =0 ; i < nextActions.length; i++){
+        nextActions[i].reset();
+        nextActions[i].play();
+        nextActions[i].fadeIn(transitionTime);
+      }
+      currentActions = nextActions;
     }
   }
   

--- a/type_templates/glb.js
+++ b/type_templates/glb.js
@@ -256,13 +256,11 @@ export default e => {
   };
   const _getActions = (actionStrings) => {
     const result = [];
-    actionStrings = actionStrings.length ? actionStrings :[actionStrings]
-    if (actionStrings.length){
-      for (let i =0; i < actionStrings.length ; i++){
-        if (actionStrings[i]){
-          const act = actions.filter(a => a._clip.name.toLowerCase() === actionStrings[i].toLowerCase())[0];
-          if (act) result.push(act); 
-        }
+    actionStrings = actionStrings.length ? actionStrings : [actionStrings];
+    for (let i =0; i < actionStrings.length ; i++){
+      if (actionStrings[i]){
+        const act = actions.filter(a => a._clip.name.toLowerCase() === actionStrings[i].toLowerCase())[0];
+        if (act) result.push(act); 
       }
     }
     return result;

--- a/type_templates/glb.js
+++ b/type_templates/glb.js
@@ -82,11 +82,12 @@ export default e => {
           const animationEnabled = !!(app.getComponent('animation') ?? true);
 
           if (animationEnabled && animations.length > 0){
-            mixer = new THREE.AnimationMixer(o);
+            mixer = new THREE.AnimationMixer(o);    // create the animation mixer with the root of the glb file
             for (let i =0 ; i < animations.length; i++){
               actions.push(mixer.clipAction(animations[i]));
+              actions[i].clampWhenFinished = true;  // make sure to stop it in the last frame just in case loop is set to false
             }
-            const idleAction = _getActions(['idle']);
+            const idleAction = _getActions('idle');
             currentActions = idleAction.length > 0 ? idleAction : actions;
             for (let i =0 ; i < currentActions.length; i++){
               currentActions[i].play();
@@ -264,7 +265,7 @@ export default e => {
       }
     }
     if (result.length === 0)
-      console.warn("No animations found");
+      console.warn("No animations found: " + actionStrings);
     return result;
   }
   app.addEventListener('wearupdate', e => {
@@ -336,13 +337,14 @@ export default e => {
     }
   };
 
-  app.playAnimations = (animationStrings, transitionTime = 0.1) => {
+  app.playAnimations = (animationStrings, transitionTime = 0.1, animationLoop = true) => {
     if (mixer){
       const nextActions = animationStrings ? _getActions(animationStrings) : actions;
       for (let i =0 ; i < currentActions.length; i++){
         currentActions[i].fadeOut(transitionTime);
       }
       for (let i =0 ; i < nextActions.length; i++){
+        nextActions[i].loop = animationLoop ? THREE.LoopRepeat : THREE.LoopOnce;
         nextActions[i].reset();
         nextActions[i].play();
         nextActions[i].fadeIn(transitionTime);

--- a/type_templates/glb.js
+++ b/type_templates/glb.js
@@ -265,7 +265,7 @@ export default e => {
       }
     }
     if (result.length === 0)
-      console.warn("No animations found: " + actionStrings);
+      console.warn("No animation(s) found with name(s): " + actionStrings);
     return result;
   }
   app.addEventListener('wearupdate', e => {


### PR DESCRIPTION
1- Right now, using animation Mixers from Totum import is not possible, theyre not exposed, and theyre only meant to be used to play an idle animation when importing a glb file, only if it includes an animation called 'idle', if not, it plays all the animations the object has.

2- This might work for some cases were the animation clips were separated to create an idle animation, but in others it comes with a wierd looking combined animation (silsword), and often not desired (other example would be the combination of walk animation + idle animation + run animation), it would be nice to be able to decide which animation comes first.


https://user-images.githubusercontent.com/1117257/183790298-e1b423fc-96ce-4317-9f36-0860023cf617.mp4


3- Now the problem is that multiple mixers are being created because theyre based on the 3d Object that animates first from the hierarchy, and that leads to some complex thinking when trying to animate, so just exposing all the mixers from Totum would not be a good solution either.

4- I tried to see how its being solved in other cases were animations are called, and noticed animation mixers from Totum were not being used at all:

pet.js = its creating a custom mixer, but Totum is actually making sure it doesnt create double animation mixers.
silsword = its setting the animations to false, and its actually being animated by the character
chest = its creating its own animation mixer.

5- After some research and testings, I noticed it is possible to create a single animation mixer using the Root of the scene of the glb file, this helps alot because we're no longer having mulitple mixers, and now we are actually able to "Mix" animations. So far while testing, there has been no wierd animation by setting the scene as the mixer's root, everyhting seems to be working fine. (But might as well need some more testings in this section)


https://user-images.githubusercontent.com/1117257/183790740-ee1e680d-d1af-402c-8dd1-f36d78b0cd81.mp4


6- To keep consistency in the way it's working right now with multiple mixers, im doing a similar procedure but with only one mixer, and that is: validate if there is idle animation and play it, if not play all animations (but this time with only one mixer), this will help to avoid any undesired changes of the way apps are currently working

7- And Finally to get the most out if it, I tried making an API call in totum that lets you play animations by name/array, duration of transition and looping, this will help us alot in the future to just make the api call and decide which animations we want to play (maybe an idle combined with running, maybe just walk). This will reduce code complexity and size.

8- This is a Work in progress,I wanted to code down all the ideas and test them out to see if this worked and it seems it does, but I believe it still needs alot of testing and approval to see if its the path we're looking for :), here is a test of a few lines of how this call can be used (I used the animations from silsword, I think theyre great)

https://user-images.githubusercontent.com/1117257/183791097-970b0651-3a6b-4dbe-bd2c-206f5513f25e.mp4


