### PR TITLE
Remove adding object3d from component property

### DIFF
--- a/type_templates/glb.js
+++ b/type_templates/glb.js
@@ -267,13 +267,11 @@ export default e => {
           const {instanceId} = app;
           const localPlayer = useLocalPlayer();
 
-          const rideBone = sitSpec.sitBone ? rideMesh.skeleton.bones.find(bone => bone.name === sitSpec.sitBone) : null;
           const sitAction = {
             type: 'sit',
             time: 0,
             animation: sitSpec.subtype,
-            controllingId: instanceId,
-            controllingBone: rideBone,
+            controllingId: instanceId
           };
           localPlayer.setControlAction(sitAction);
         }


### PR DESCRIPTION
-Infinite call stack happening because were saving the object3d as a property of component.
-Also checked and we're not using this property
Fix for:
https://github.com/webaverse/app/issues/3452