### PR TITLE
Fix avatar capsule size math

### DIFF
--- a/type_templates/vrm.js
+++ b/type_templates/vrm.js
@@ -55,7 +55,7 @@ export default e => {
       const halfAvatarCapsuleHeight = (height + width) / 2; // (full world height of the capsule) / 2
 
       localMatrix.compose(
-        localVector.set(0, halfAvatarCapsuleHeight, 0), // start position: ;
+        localVector.set(0, halfAvatarCapsuleHeight, 0), // start position
         localQuaternion.setFromAxisAngle(localVector2.set(0, 0, 1), Math.PI / 2), // rotate 90 degrees 
         localVector2.set(capsuleRadius, halfAvatarCapsuleHeight, capsuleRadius)
       )

--- a/type_templates/vrm.js
+++ b/type_templates/vrm.js
@@ -47,16 +47,17 @@ export default e => {
     // globalThis.avatarRenderer = avatarRenderer;
 
      const _addPhysics = () => {
-      const HEAD_HEIGHT = 0.15; // head height is zero in initialization so we need to take it into account
       const {height, width} = app.avatarRenderer.getAvatarSize();
 
-      const radius = width / 2;
-      const capsuleHalfHeight = (height + HEAD_HEIGHT) / 2;
+      const capsuleRadius = width / 2;
+      const capsuleHalfHeight = height / 2;
+
+      const halfAvatarCapsuleHeight = (height + width) / 2; // (full world height of the capsule) / 2
 
       localMatrix.compose(
-        localVector.set(0, capsuleHalfHeight + (HEAD_HEIGHT / 2), 0), // start position
+        localVector.set(0, halfAvatarCapsuleHeight, 0), // start position: ;
         localQuaternion.setFromAxisAngle(localVector2.set(0, 0, 1), Math.PI / 2), // rotate 90 degrees 
-        localVector2.set(radius, capsuleHalfHeight / 2, radius)
+        localVector2.set(capsuleRadius, halfAvatarCapsuleHeight, capsuleRadius)
       )
         .premultiply(app.matrixWorld)
         .decompose(localVector, localQuaternion, localVector2);
@@ -64,7 +65,7 @@ export default e => {
       const physicsId = physics.addCapsuleGeometry(
         localVector,
         localQuaternion,
-        radius,
+        capsuleRadius,
         capsuleHalfHeight,
         false
       );


### PR DESCRIPTION
the math for calculating avatar capsule size was wrong before : https://github.com/webaverse/totum/pull/139
initially I thought that the head height is not being calculated correctly, but after some investigation I noticed that's not the case...
so I rewrote the math

Result :
![image](https://user-images.githubusercontent.com/64514807/189119519-51225629-b36f-4337-b698-805c4533c100.png)
![image](https://user-images.githubusercontent.com/64514807/189119527-b8923820-1d81-465c-af91-a7b07fdcbce3.png)
![image](https://user-images.githubusercontent.com/64514807/189120983-49aee64c-62c1-4c51-abd8-f0a4211fe9b7.png)
