### PR TITLE
Added gltf OMI_collider extension support.

### DIFF
--- a/type_templates/glb.js
+++ b/type_templates/glb.js
@@ -202,6 +202,8 @@ export default e => {
             console.warn('glb unknown physics component', physicsComponent);
           }
         };
+
+        const _hasNegativeScale = scale => Object.values(scale).some(v => v <= 0)
         
         switch (physicsComponent.type) {
           case 'triangleMesh': {
@@ -231,6 +233,11 @@ export default e => {
 
               node.matrixWorld.decompose(position, rotation, scale);
 
+              if (_hasNegativeScale(scale)) {
+                console.warn('Object ' + nodeDef.name + ' has negative scale which is not supported.')
+                return;
+              }
+              
               const shortestScaleAxis = scale.toArray().sort()[0];
               
               let physicsId;
@@ -307,6 +314,7 @@ export default e => {
                 }
                   
                 case 'compound': {
+                  console.warn('Object ' + nodeDef.name + ' is using OMI_collider type "compound" which is not supported.');
                   physicsId = null;
                   break;
                 }


### PR DESCRIPTION
Added support for the OMI_collider extension proposed by the OMI group in the following specification.
https://github.com/cyberneticocult/gltf-extensions-omi-collider/tree/main/extensions/2.0/OMI_collider

Scenes can be exported with an extension addon for the blender gltf exporter.
https://github.com/cyberneticocult/gltf-blender-io-omi-collision-extension

Test data for scenes that use the OMI_collider extension can be found at the following static resource urls.
https://cyberneticocult.github.io/webaverse-omi-collider-examples/boxes-glb/
https://cyberneticocult.github.io/webaverse-omi-collider-examples/boxes-gltf/boxes.gltf
https://cyberneticocult.github.io/webaverse-omi-collider-examples/collider-types-glb/
https://cyberneticocult.github.io/webaverse-omi-collider-examples/collider-types-gltf/collider_types.gltf