### PR TITLE
Fix physics component

### DIFF
--- a/type_templates/glb.js
+++ b/type_templates/glb.js
@@ -27,7 +27,7 @@ export default e => {
     app.setComponent(key, value);
   }
 
-  // ? true by default
+  // * true by default
   let appHasPhysics = true;
   const hasPhysicsComponent = app.hasComponent('physics');
   if (hasPhysicsComponent) {

--- a/type_templates/glb.js
+++ b/type_templates/glb.js
@@ -202,11 +202,14 @@ export default e => {
       
       // * Physics
       const _addPhysics = async () => {
-        physicsId = physics.addGeometry(o);
+        const physicsId = physics.addGeometry(o);
+        physicsIds.push(physicsId);
       };
+
       if (appHasPhysics) {
         _addPhysics();
       }
+
       o.traverse(o => {
         if (o.isMesh) {
           o.frustumCulled = false;

--- a/type_templates/glb.js
+++ b/type_templates/glb.js
@@ -31,7 +31,8 @@ export default e => {
   let appHasPhysics = true;
   const hasPhysicsComponent = app.hasComponent('physics');
   if (hasPhysicsComponent) {
-    appHasPhysics = value;
+    const physicsComponent = app.getComponent('physics');
+    appHasPhysics = physicsComponent;
   }
 
   app.glb = null;

--- a/type_templates/glb.js
+++ b/type_templates/glb.js
@@ -22,18 +22,10 @@ export default e => {
   const localPlayer = useLocalPlayer();
 
   const srcUrl = ${this.srcUrl};
-
   for (const {key, value} of components) {
     app.setComponent(key, value);
   }
-
-  // ? true by default
-  let appHasPhysics = true;
-  const hasPhysicsComponent = app.hasComponent('physics');
-  if (hasPhysicsComponent) {
-    appHasPhysics = value;
-  }
-
+  
   app.glb = null;
   const animationMixers = [];
   const uvScrolls = [];
@@ -200,12 +192,36 @@ export default e => {
       app.add(o);
       o.updateMatrixWorld();
       
-      // * Physics
-      const _addPhysics = async () => {
-        physicsId = physics.addGeometry(o);
+      const _addPhysics = async physicsComponent => {
+        let physicsId;
+        switch (physicsComponent.type) {
+          case 'triangleMesh': {
+            physicsId = physics.addGeometry(o);
+            break;
+          }
+          case 'convexMesh': {
+            physicsId = physics.addConvexGeometry(o);
+            break;
+          }
+          default: {
+            physicsId = null;
+            break;
+          }
+        }
+        if (physicsId !== null) {
+          physicsIds.push(physicsId);
+        } else {
+          console.warn('glb unknown physics component', physicsComponent);
+        }
       };
-      if (appHasPhysics) {
-        _addPhysics();
+      let physicsComponent = app.getComponent('physics');
+      if (physicsComponent) {
+        if (physicsComponent === true) {
+          physicsComponent = {
+            type: 'triangleMesh',
+          };
+        }
+        _addPhysics(physicsComponent);
       }
       o.traverse(o => {
         if (o.isMesh) {

--- a/type_templates/glb.js
+++ b/type_templates/glb.js
@@ -22,10 +22,18 @@ export default e => {
   const localPlayer = useLocalPlayer();
 
   const srcUrl = ${this.srcUrl};
+
   for (const {key, value} of components) {
     app.setComponent(key, value);
   }
-  
+
+  // ? true by default
+  let appHasPhysics = true;
+  const hasPhysicsComponent = app.hasComponent('physics');
+  if (hasPhysicsComponent) {
+    appHasPhysics = value;
+  }
+
   app.glb = null;
   const animationMixers = [];
   const uvScrolls = [];
@@ -192,36 +200,12 @@ export default e => {
       app.add(o);
       o.updateMatrixWorld();
       
-      const _addPhysics = async physicsComponent => {
-        let physicsId;
-        switch (physicsComponent.type) {
-          case 'triangleMesh': {
-            physicsId = physics.addGeometry(o);
-            break;
-          }
-          case 'convexMesh': {
-            physicsId = physics.addConvexGeometry(o);
-            break;
-          }
-          default: {
-            physicsId = null;
-            break;
-          }
-        }
-        if (physicsId !== null) {
-          physicsIds.push(physicsId);
-        } else {
-          console.warn('glb unknown physics component', physicsComponent);
-        }
+      // * Physics
+      const _addPhysics = async () => {
+        physicsId = physics.addGeometry(o);
       };
-      let physicsComponent = app.getComponent('physics');
-      if (physicsComponent) {
-        if (physicsComponent === true) {
-          physicsComponent = {
-            type: 'triangleMesh',
-          };
-        }
-        _addPhysics(physicsComponent);
+      if (appHasPhysics) {
+        _addPhysics();
       }
       o.traverse(o => {
         if (o.isMesh) {


### PR DESCRIPTION
I investigated the "physics" parameter issue in the .scn files
and I noticed that parameter is not being used anywhere
and the only reason we have had physics in objects is because we set it to true manually ( in app-manager.js )

so here's what I suggest we do :
1. put the "physics" parameter in the "components" array in the .scn file
2. make sure all of our scene files follow that rule
3. update our docs

and finally here's what the user experiences :
- If the `physics` component is not specified in the .scn file, we're going to enable physics  for the object by default 
- If the `physics` component is set to `true` we enable and if it's set to `false` we disable physics for that object